### PR TITLE
feat: update file size limit to 500MB in ErrorCode and FileApiController

### DIFF
--- a/src/main/java/com/example/newsper/api/FileApiController.java
+++ b/src/main/java/com/example/newsper/api/FileApiController.java
@@ -55,8 +55,8 @@ public class FileApiController {
 
                 log.info("파일 이름 : " + file.getOriginalFilename());
                 log.info("파일 크기 : " + file.getSize());
-
-                if (file.getSize() > 5000000) {
+                // 500MB 제한
+                if (file.getSize() > 1024*1024*500) {
                     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorCodeService.setErrorCodeBody(ErrorCode.FILE_SIZE_EXCEEDED));
                 }
 

--- a/src/main/java/com/example/newsper/constant/ErrorCode.java
+++ b/src/main/java/com/example/newsper/constant/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode {
     BOARD_NO_ACCESS(-301, "게시판 접근 권한 없음"),
     BOARD_NO_WRITE_PERMISSION(-302, "게시글 쓰기 권한 없음"),
     BOARD_NO_EDIT_PERMISSION(-303, "게시글 수정/삭제 권한 없음"),
-    FILE_SIZE_EXCEEDED(-401, "파일 용량 10MB 초과"),
+    FILE_SIZE_EXCEEDED(-401, "파일 용량 500MB 초과"),
     FILE_NAME_INVALID(-402, "파일 이름이 너무 길거나 NULL"),
     ADMIN_PERMISSION_UNCHANGEABLE(-501, "관리자의 권한은 바꿀 수 없음"),
     ASSIGNMENT_CREATION_MEMBER_ONLY(-601, "정회원 이상 과제 작성 가능"),


### PR DESCRIPTION
Close #44 

This pull request includes changes to update the file size limit for uploads and the corresponding error message. The most important changes are:

File size limit update:

* [`src/main/java/com/example/newsper/api/FileApiController.java`](diffhunk://#diff-d1fadc2252cab5b35fe64f4ccab0621651e7efe8d1012a4311cfad3de3a1a623L58-R59): Updated the file size limit from 5MB to 500MB.

Error message update:

* [`src/main/java/com/example/newsper/constant/ErrorCode.java`](diffhunk://#diff-995b6d90613928e373774e086c7292380a9e43c1584458b36e147571158ca135L20-R20): Updated the error message for file size exceeded from 10MB to 500MB.