### PR TITLE
feat: add file download filter to handle content disposition for various file types

### DIFF
--- a/src/main/java/com/example/newsper/config/WebConfig.java
+++ b/src/main/java/com/example/newsper/config/WebConfig.java
@@ -1,0 +1,77 @@
+package com.example.newsper.config;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+import java.io.IOException;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public FilterRegistrationBean<FileDownloadFilter> fileDownloadFilter() {
+        FilterRegistrationBean<FileDownloadFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new FileDownloadFilter());
+        // Apply filter to all upload files
+        registrationBean.addUrlPatterns(
+                "/profile/*",
+                "/article/*",
+                "/assignment/*",
+                "/submit/*"
+        );
+        registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registrationBean;
+    }
+
+    public static class FileDownloadFilter implements Filter {
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+            HttpServletResponse httpResponse = (HttpServletResponse) response;
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            String path = httpRequest.getRequestURI();
+            String filename = path.substring(path.lastIndexOf('/') + 1);
+            String fileType = filename.substring(filename.lastIndexOf('.') + 1);
+            // check file is inlinable type(for img, iframe tag)
+            boolean isInline = false;
+            switch (fileType) {
+                case "jpg":
+                case "jpeg":
+                    httpResponse.setContentType("image/jpeg");
+                    isInline = true;
+                    break;
+                case "png":
+                    httpResponse.setContentType("image/png");
+                    isInline = true;
+                    break;
+                case "gif":
+                    httpResponse.setContentType("image/gif");
+                    isInline = true;
+                    break;
+                case "bmp":
+                    httpResponse.setContentType("image/bmp");
+                    isInline = true;
+                    break;
+                case "pdf":
+                    httpResponse.setContentType("application/pdf");
+                    isInline = true;
+                    break;
+                default:
+                    httpResponse.setContentType("application/octet-stream");
+                    break;
+            }
+            if (isInline) {
+                httpResponse.setHeader("Content-Disposition", "inline; filename=\"" + filename + "\"");
+            } else {
+                httpResponse.setHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
+            }
+            chain.doFilter(request, response);
+        }
+    }
+}
+

--- a/src/main/java/com/example/newsper/config/WebConfig.java
+++ b/src/main/java/com/example/newsper/config/WebConfig.java
@@ -35,13 +35,17 @@ public class WebConfig {
             HttpServletResponse httpResponse = (HttpServletResponse) response;
             HttpServletRequest httpRequest = (HttpServletRequest) request;
             String path = httpRequest.getRequestURI();
-            String filename = path.substring(path.lastIndexOf('/') + 1);
+            String filename = path.substring(path.lastIndexOf('/') + 1).toLowerCase();
             String fileType = filename.substring(filename.lastIndexOf('.') + 1);
             // check file is inlinable type(for img, iframe tag)
             boolean isInline = false;
             switch (fileType) {
                 case "jpg":
                 case "jpeg":
+                case "jpe":
+                case "jif":
+                case "jfif":
+                case "jfi":
                     httpResponse.setContentType("image/jpeg");
                     isInline = true;
                     break;
@@ -54,11 +58,114 @@ public class WebConfig {
                     isInline = true;
                     break;
                 case "bmp":
+                case "dib":
                     httpResponse.setContentType("image/bmp");
+                    isInline = true;
+                    break;
+                case "svg":
+                    httpResponse.setContentType("image/svg+xml");
+                    isInline = true;
+                    break;
+                case "svgz":
+                    httpResponse.setContentType("image/svg+xml");
+                    httpResponse.setHeader("Content-Encoding", "gzip");
+                    isInline = true;
+                    break;
+                case "webp":
+                    httpResponse.setContentType("image/webp");
+                    isInline = true;
+                    break;
+                case "avif":
+                    httpResponse.setContentType("image/avif");
+                    isInline = true;
+                    break;
+                case "jxl":
+                    httpResponse.setContentType("image/jxl");
+                    isInline = true;
+                    break;
+                case "apng":
+                    httpResponse.setContentType("image/apng");
+                    isInline = true;
+                    break;
+                case "ico":
+                    httpResponse.setContentType("image/x-icon");
+                    isInline = true;
+                    break;
+                case "cur":
+                    httpResponse.setContentType("image/vnd.microsoft.icon");
+                    isInline = true;
+                    break;
+                case "tif":
+                case "tiff":
+                    httpResponse.setContentType("image/tiff");
+                    isInline = true;
+                    break;
+                case "jp2":
+                case "j2k":
+                case "jpf":
+                case "jpx":
+                case "jpm":
+                case "jpg2":
+                case "mj2":
+                    httpResponse.setContentType("image/jp2");
+                    isInline = true;
+                    break;
+                case "heic":
+                case "heif":
+                case "heics":
+                case "heifs":
+                case "avci":
+                case "avcs":
+                case "hif":
+                    httpResponse.setContentType("image/heic");
                     isInline = true;
                     break;
                 case "pdf":
                     httpResponse.setContentType("application/pdf");
+                    isInline = true;
+                    break;
+                case "mp4":
+                    httpResponse.setContentType("video/mp4");
+                    isInline = true;
+                    break;
+                case "webm":
+                    httpResponse.setContentType("video/webm");
+                    isInline = true;
+                    break;
+                case "mkv":
+                    httpResponse.setContentType("video/x-matroska");
+                    isInline = true;
+                    break;
+                case "avi":
+                    httpResponse.setContentType("video/x-msvideo");
+                    isInline = true;
+                    break;
+                case "wmv":
+                    httpResponse.setContentType("video/x-ms-wmv");
+                    isInline = true;
+                    break;
+                case "flv":
+                    httpResponse.setContentType("video/x-flv");
+                    isInline = true;
+                    break;
+                case "mov":
+                    httpResponse.setContentType("video/quicktime");
+                    isInline = true;
+                    break;
+                case "ogg":
+                    httpResponse.setContentType("video/ogg");
+                    isInline = true;
+                    break;
+                case "mp3":
+                    httpResponse.setContentType("audio/mpeg");
+                    isInline = true;
+                    break;
+                case "wav":
+                    httpResponse.setContentType("audio/wav");
+                    isInline = true;
+                    break;
+                case "flac":
+                    httpResponse.setContentType("audio/flac");
                     isInline = true;
                     break;
                 default:


### PR DESCRIPTION
This pull request introduces a new configuration class `WebConfig` to the project. The main purpose of this class is to add a filter for handling file downloads, ensuring that certain file types are displayed inline while others are downloaded as attachments.

Key changes include:

* Added `WebConfig` class to configure a new filter for file downloads. The filter applies to specific URL patterns and sets the content type and disposition headers based on file type.
* Implemented `FileDownloadFilter` class within `WebConfig` to handle the logic for determining whether files should be displayed inline or downloaded as attachments based on their MIME type.

Closes #47 